### PR TITLE
Add UrlSearchParams reading

### DIFF
--- a/psc-package.json
+++ b/psc-package.json
@@ -3,6 +3,8 @@
     "set": "aff-4.0-27-Oct-2017",
     "source": "https://github.com/justinwoo/package-sets.git",
     "depends": [
+        "dom",
+        "argonaut-core",
         "aff",
         "halogen",
         "prelude",

--- a/src/Main.purs
+++ b/src/Main.purs
@@ -1,9 +1,14 @@
 module Main where
 
 import Prelude
+
 import Control.Monad.Eff (Eff)
 import Control.Monad.Eff.Console (CONSOLE, log)
+import DOM (DOM)
+import URLSearchParams as URLParams
 
-main :: forall e. Eff (console :: CONSOLE | e) Unit
+main :: forall e. Eff (dom :: DOM, console :: CONSOLE | e) Unit
 main = do
-  log "Hello sailor!"
+  token     <- URLParams.get "private_token"
+  gitlabUrl <- URLParams.get "gitlab_url"
+  log (token <> " " <> gitlabUrl)

--- a/src/URLSearchParams.js
+++ b/src/URLSearchParams.js
@@ -1,0 +1,8 @@
+"use strict";
+
+exports.get = function(paramName) {
+  return function() {
+    var url = new URL(window.location.toString());
+    return url.searchParams.get(paramName);
+  };
+};

--- a/src/URLSearchParams.purs
+++ b/src/URLSearchParams.purs
@@ -1,0 +1,6 @@
+module URLSearchParams where
+
+import Control.Monad.Eff (Eff)
+import DOM (DOM)
+
+foreign import get :: forall e. String -> Eff (dom :: DOM | e) String


### PR DESCRIPTION
Script needs to read secrets from URL Search Parameters.
Current js implementation uses [URLSearchParams](https://developer.mozilla.org/en-US/docs/Web/API/URLSearchParams) DOM object for this job, but `purescript-dom` does not support it, so we do it with FFI.