### PR TITLE
Add Model

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ node_modules
 output
 .psc-package
 app.js
+.psci_modules

--- a/index.html
+++ b/index.html
@@ -18,7 +18,7 @@
      body {
        padding-top: 3.5rem;
      }
-     .app table {
+     table {
        text-align: center;
      }
 
@@ -38,21 +38,6 @@
     <nav class="navbar navbar-dark bg-dark fixed-top">
       <a class="navbar-brand" href="#">Gitlab Pipelines</a>
     </nav>
-
-    <div class="app">
-      <table class="table table-inverse">
-        <thead>
-          <tr>
-            <th>Status</th>
-            <th>Repo</th>
-            <th>Commit</th>
-            <th>Stages</th>
-            <th>Time</th>
-          </tr>
-        </thead>
-        <tbody id="pipelines"></tbody>
-      </table>
-    </div>
 
     <script src="node_modules/jquery/dist/jquery.min.js"></script>
     <script src="node_modules/popper.js/dist/umd/popper.min.js"></script>

--- a/psc-package.json
+++ b/psc-package.json
@@ -3,6 +3,8 @@
     "set": "aff-4.0-27-Oct-2017",
     "source": "https://github.com/justinwoo/package-sets.git",
     "depends": [
+        "datetime",
+        "js-date",
         "transformers",
         "debug",
         "foreign",

--- a/psc-package.json
+++ b/psc-package.json
@@ -3,6 +3,7 @@
     "set": "aff-4.0-27-Oct-2017",
     "source": "https://github.com/justinwoo/package-sets.git",
     "depends": [
+        "uri",
         "datetime",
         "js-date",
         "transformers",

--- a/src/Dashboard/Component.purs
+++ b/src/Dashboard/Component.purs
@@ -1,0 +1,61 @@
+module Dashboard.Component where
+
+import Prelude
+
+import Dashboard.Model (PipelineRow, createdDateTime)
+import Dashboard.View (formatPipeline)
+import Data.Array (elem, filter, reverse, sortWith, take)
+import Data.Maybe (Maybe(..))
+import Halogen as H
+import Halogen.HTML as HH
+import Halogen.HTML.Properties as HP
+
+type State = Array PipelineRow
+
+data Query a = UpsertProjectPipelines (Array PipelineRow) a
+
+
+ui :: forall m. H.Component HH.HTML Query Unit Void m
+ui =
+  H.component
+    { initialState: const initialState
+    , render
+    , eval
+    , receiver: const Nothing
+    }
+  where
+
+  initialState :: State
+  initialState = []
+
+  render :: State -> H.ComponentHTML Query
+  render pipelines =
+    HH.table
+      [ HP.classes [ H.ClassName "table"
+                  , H.ClassName "table-inverse"
+                  ]
+      ]
+      [ HH.thead_
+          [ HH.tr_ [ HH.th_ [ HH.text "Status" ]
+                   , HH.th_ [ HH.text "Repo" ]
+                   , HH.th_ [ HH.text "Commit" ]
+                   , HH.th_ [ HH.text "Stages" ]
+                   , HH.th_ [ HH.text "Time" ]
+                   ]
+          ]
+      , HH.tbody_ $ map formatPipeline pipelines
+      ]
+
+  eval :: Query ~> H.ComponentDSL State Query Void m
+  eval = case _ of
+    UpsertProjectPipelines pipelines next -> do
+      state <- H.get
+      H.put
+        $ take 40
+        $ reverse
+        $ sortWith createdDateTime
+        -- Always include the pipelines passed as new data.
+        -- Filter out of the state the pipelines that we have in the new data,
+        -- and merge the remaining ones to get the new state.
+        $ pipelines <> filter (\pr -> not $ elem pr.id (map _.id pipelines)) state
+      pure next

--- a/src/Dashboard/Component.purs
+++ b/src/Dashboard/Component.purs
@@ -4,7 +4,7 @@ import Prelude
 
 import Dashboard.Model (PipelineRow, createdDateTime)
 import Dashboard.View (formatPipeline)
-import Data.Array (elem, filter, reverse, sortWith, take)
+import Data.Array as Array
 import Data.Maybe (Maybe(..))
 import Halogen as H
 import Halogen.HTML as HH
@@ -48,14 +48,13 @@ ui =
 
   eval :: Query ~> H.ComponentDSL State Query Void m
   eval = case _ of
-    UpsertProjectPipelines pipelines next -> do
-      state <- H.get
-      H.put
-        $ take 40
-        $ reverse
-        $ sortWith createdDateTime
+    UpsertProjectPipelines pipelines next -> next <$ do
+      H.modify
+        $ Array.take 40
+        <<< Array.reverse
+        <<< Array.sortWith createdDateTime
         -- Always include the pipelines passed as new data.
         -- Filter out of the state the pipelines that we have in the new data,
         -- and merge the remaining ones to get the new state.
-        $ pipelines <> filter (\pr -> not $ elem pr.id (map _.id pipelines)) state
-      pure next
+        <<< (pipelines <> _)
+        <<< Array.filter (\pr -> not $ Array.elem pr.id (map _.id pipelines))

--- a/src/Dashboard/Model.purs
+++ b/src/Dashboard/Model.purs
@@ -46,12 +46,16 @@ statusIcons status = case status of
   JobSkipped  -> "arrow-circle-o-right"
 
 getUniqueStages :: Jobs -> Array JobStatus
-getUniqueStages js = map (\j -> j.status) $ sortWith (\j -> j.id) lastJobs
+getUniqueStages jobs = map jobStatus
+                       $ sortWith jobId
+                       $ catMaybes
+                       $ map (\grp -> last
+                                      $ sortWith jobId
+                                      $ fromNonEmpty (:) grp)
+                       $ groupBy (\a b -> a.name == b.name)
+                       $ sortWith jobName jobs
   where
-    grouped = groupBy (\a b -> a.name == b.name) (sortWith (\j -> j.name) js)
-    lastJobs = catMaybes
-               $ map (\g -> last
-                            $ sortWith (\j -> j.id)
-                            $ fromNonEmpty (:) g)
-               grouped
+    jobId     = \j -> j.id
+    jobStatus = \j -> j.status
+    jobName   = \j -> j.name
 

--- a/src/Dashboard/Model.purs
+++ b/src/Dashboard/Model.purs
@@ -3,11 +3,15 @@ module Dashboard.Model where
 import Data.Array
 import Data.DateTime
 import Data.JSDate
-import Data.NonEmpty
+import Data.NonEmpty (NonEmpty)
+import Data.NonEmpty as NE
 import Data.Time.Duration
-import Data.URI
+import Data.URI (URI)
+import Data.URI as URI
 import Gitlab
 import Prelude
+import Data.Maybe
+import Data.Either
 
 import Halogen.HTML.Core (ClassName(..))
 
@@ -20,7 +24,7 @@ type PipelineRow =
   , status      :: PipelineStatus
   , id          :: PipelineId
   , project     :: Project
-  , stages      :: Jobs
+  , stages      :: Array JobStatus
   , duration    :: Milliseconds
   }
 
@@ -46,16 +50,11 @@ statusIcons status = case status of
   JobSkipped  -> "arrow-circle-o-right"
 
 getUniqueStages :: Jobs -> Array JobStatus
-getUniqueStages jobs = map jobStatus
-                       $ sortWith jobId
-                       $ catMaybes
-                       $ map (\grp -> last
-                                      $ sortWith jobId
-                                      $ fromNonEmpty (:) grp)
+getUniqueStages jobs = map _.status
+                       $ sortWith _.id
+                       $ mapMaybe (\grp -> last
+                                           $ sortWith _.id
+                                           $ NE.fromNonEmpty (:) grp)
                        $ groupBy (\a b -> a.name == b.name)
-                       $ sortWith jobName jobs
-  where
-    jobId     = \j -> j.id
-    jobStatus = \j -> j.status
-    jobName   = \j -> j.name
+                       $ sortWith _.name jobs
 

--- a/src/Dashboard/Model.purs
+++ b/src/Dashboard/Model.purs
@@ -24,24 +24,22 @@ type PipelineRow =
 
 rowColors :: PipelineStatus -> ClassName
 rowColors status = case status of
-  "running"  -> ClassName "bg-primary"
-  "pending"  -> ClassName "bg-info"
-  "success"  -> ClassName "bg-success"
-  "failed"   -> ClassName "bg-danger"
-  "canceled" -> ClassName "bg-warning"
-  "skipped"  -> ClassName "bg-none"
-  _          -> ClassName "bg-none"
+  Running  -> ClassName "bg-primary"
+  Pending  -> ClassName "bg-info"
+  Success  -> ClassName "bg-success"
+  Failed   -> ClassName "bg-danger"
+  Canceled -> ClassName "bg-warning"
+  Skipped  -> ClassName "bg-none"
 
 -- TODO: return an HTML element instead. See status2icon
 statusIcons :: JobStatus -> String
 statusIcons status = case status of
-  "created"  -> "dot-circle-o"
-  "manual"   -> "user-circle-o"
-  "running"  -> "refresh"
-  "pending"  -> "question-circle-o"
-  "success"  -> "check-circle-o"
-  "failed"   -> "times-circle-o"
-  "canceled" -> "stop-circle-o"
-  "skipped"  -> "arrow-circle-o-right"
-  _          -> ""
+  JobCreated  -> "dot-circle-o"
+  JobManual   -> "user-circle-o"
+  JobRunning  -> "refresh"
+  JobPending  -> "question-circle-o"
+  JobSuccess  -> "check-circle-o"
+  JobFailed   -> "times-circle-o"
+  JobCanceled -> "stop-circle-o"
+  JobSkipped  -> "arrow-circle-o-right"
 

--- a/src/Dashboard/Model.purs
+++ b/src/Dashboard/Model.purs
@@ -76,16 +76,13 @@ makePipelineRow jobs =
                   $ mapMaybe (\j -> toDateTime =<< j.finished_at) pipelineJobs
       pure $ diff started finished
 
-
-makePipelineRows :: Jobs -> Array PipelineRow
-makePipelineRows jobs = sortWith createdDateTime
+-- | Given all the Jobs for a Project, makes a PipelineRow out of each Pipeline
+makeProjectRows :: Jobs -> Array PipelineRow
+makeProjectRows jobs = sortWith createdDateTime
                         $ map makePipelineRow
-                        $ groupBy (\a b -> (getProjectName a) == (getProjectName b))
-                        $ sortWith getProjectName jobs
+                        $ groupBy (\a b -> (_.pipeline.id a) == (_.pipeline.id b))
+                        $ sortWith _.pipeline.id jobs
   where
-    getProjectName :: Job -> ProjectName
-    getProjectName job = (fromMaybe defaultProject job.project).name
-
     createdDateTime :: PipelineRow -> DateTime
     createdDateTime job = unsafePartial $ fromJust $ toDateTime job.created
 

--- a/src/Dashboard/Model.purs
+++ b/src/Dashboard/Model.purs
@@ -1,0 +1,47 @@
+module Dashboard.Model where
+
+import Prelude
+
+import Gitlab
+import Data.URI
+import Data.JSDate
+import Data.DateTime
+import Data.Time.Duration
+import Halogen.HTML.Core (ClassName(..))
+
+type PipelineRow =
+  { authorImg   :: URI
+  , commitTitle :: String
+  , hash        :: CommitShortHash
+  , branch      :: BranchName
+  , created     :: DateTime
+  , status      :: PipelineStatus
+  , id          :: PipelineId
+  , project     :: Project
+  , stages      :: Jobs
+  , duration    :: Milliseconds
+  }
+
+rowColors :: PipelineStatus -> ClassName
+rowColors status = case status of
+  "running"  -> ClassName "bg-primary"
+  "pending"  -> ClassName "bg-info"
+  "success"  -> ClassName "bg-success"
+  "failed"   -> ClassName "bg-danger"
+  "canceled" -> ClassName "bg-warning"
+  "skipped"  -> ClassName "bg-none"
+  _          -> ClassName "bg-none"
+
+-- TODO: return an HTML element instead. See status2icon
+statusIcons :: JobStatus -> String
+statusIcons status = case status of
+  "created"  -> "dot-circle-o"
+  "manual"   -> "user-circle-o"
+  "running"  -> "refresh"
+  "pending"  -> "question-circle-o"
+  "success"  -> "check-circle-o"
+  "failed"   -> "times-circle-o"
+  "canceled" -> "stop-circle-o"
+  "skipped"  -> "arrow-circle-o-right"
+  _          -> ""
+

--- a/src/Dashboard/Model.purs
+++ b/src/Dashboard/Model.purs
@@ -1,12 +1,14 @@
 module Dashboard.Model where
 
+import Data.Array
+import Data.DateTime
+import Data.JSDate
+import Data.NonEmpty
+import Data.Time.Duration
+import Data.URI
+import Gitlab
 import Prelude
 
-import Gitlab
-import Data.URI
-import Data.JSDate
-import Data.DateTime
-import Data.Time.Duration
 import Halogen.HTML.Core (ClassName(..))
 
 type PipelineRow =
@@ -42,4 +44,14 @@ statusIcons status = case status of
   JobFailed   -> "times-circle-o"
   JobCanceled -> "stop-circle-o"
   JobSkipped  -> "arrow-circle-o-right"
+
+getUniqueStages :: Jobs -> Array JobStatus
+getUniqueStages js = map (\j -> j.status) $ sortWith (\j -> j.id) lastJobs
+  where
+    grouped = groupBy (\a b -> a.name == b.name) (sortWith (\j -> j.name) js)
+    lastJobs = catMaybes
+               $ map (\g -> last
+                            $ sortWith (\j -> j.id)
+                            $ fromNonEmpty (:) g)
+               grouped
 

--- a/src/Dashboard/Model.purs
+++ b/src/Dashboard/Model.purs
@@ -28,26 +28,6 @@ type PipelineRow =
   , duration    :: Milliseconds
   }
 
-rowColors :: PipelineStatus -> ClassName
-rowColors status = case status of
-  Running  -> ClassName "bg-primary"
-  Pending  -> ClassName "bg-info"
-  Success  -> ClassName "bg-success"
-  Failed   -> ClassName "bg-danger"
-  Canceled -> ClassName "bg-warning"
-  Skipped  -> ClassName "bg-none"
-
--- TODO: return an HTML element instead. See status2icon
-statusIcons :: JobStatus -> String
-statusIcons status = case status of
-  JobCreated  -> "dot-circle-o"
-  JobManual   -> "user-circle-o"
-  JobRunning  -> "refresh"
-  JobPending  -> "question-circle-o"
-  JobSuccess  -> "check-circle-o"
-  JobFailed   -> "times-circle-o"
-  JobCanceled -> "stop-circle-o"
-  JobSkipped  -> "arrow-circle-o-right"
 
 getUniqueStages :: Jobs -> Array JobStatus
 getUniqueStages jobs = map _.status

--- a/src/Dashboard/Model.purs
+++ b/src/Dashboard/Model.purs
@@ -19,7 +19,7 @@ import Halogen.HTML.Core (ClassName(..))
 type CommitRow =
   { branch      :: BranchName
   , hash        :: CommitShortHash
-  , authorImg   :: URI
+  , authorImg   :: String
   , commitTitle :: String
   }
 

--- a/src/Dashboard/Model.purs
+++ b/src/Dashboard/Model.purs
@@ -1,8 +1,8 @@
 module Dashboard.Model where
 
-import Prelude
 import Data.Array
 import Gitlab
+import Prelude
 
 import Data.DateTime (DateTime, diff)
 import Data.JSDate (JSDate, toDateTime)
@@ -39,9 +39,6 @@ getUniqueStages jobs = map _.status
                        $ groupBy (\a b -> a.name == b.name)
                        $ sortWith _.name jobs
 
-defaultProject :: Project
-defaultProject = {id: (ProjectId 0), name: (ProjectName "")}
-
 makePipelineRow :: NonEmpty Array Job -> PipelineRow
 makePipelineRow jobs =
   { status: job.pipeline.status
@@ -59,6 +56,7 @@ makePipelineRow jobs =
   where
     job = NE.head jobs
     jobs' = NE.fromNonEmpty (:) jobs
+    defaultProject = {id: (ProjectId 0), name: (ProjectName "")}
     createdTime = job.created_at
 
     -- | Returns the total running time of a set of Jobs
@@ -78,11 +76,10 @@ makePipelineRow jobs =
 
 -- | Given all the Jobs for a Project, makes a PipelineRow out of each Pipeline
 makeProjectRows :: Jobs -> Array PipelineRow
-makeProjectRows jobs = sortWith createdDateTime
-                        $ map makePipelineRow
-                        $ groupBy (\a b -> (_.pipeline.id a) == (_.pipeline.id b))
-                        $ sortWith _.pipeline.id jobs
-  where
-    createdDateTime :: PipelineRow -> DateTime
-    createdDateTime job = unsafePartial $ fromJust $ toDateTime job.created
+makeProjectRows jobs = map makePipelineRow
+                       $ groupBy (\a b -> (_.pipeline.id a) == (_.pipeline.id b))
+                       $ sortWith _.pipeline.id jobs
+
+createdDateTime :: PipelineRow -> DateTime
+createdDateTime job = unsafePartial $ fromJust $ toDateTime job.created
 

--- a/src/Dashboard/Model.purs
+++ b/src/Dashboard/Model.purs
@@ -2,25 +2,30 @@ module Dashboard.Model where
 
 import Data.Array
 import Data.DateTime
+import Data.Either
 import Data.JSDate
-import Data.NonEmpty (NonEmpty)
-import Data.NonEmpty as NE
+import Data.Maybe
 import Data.Time.Duration
-import Data.URI (URI)
-import Data.URI as URI
 import Gitlab
 import Prelude
-import Data.Maybe
-import Data.Either
 
+import Data.NonEmpty (NonEmpty)
+import Data.NonEmpty as NE
+import Data.URI (URI)
+import Data.URI as URI
 import Halogen.HTML.Core (ClassName(..))
 
-type PipelineRow =
-  { authorImg   :: URI
-  , commitTitle :: String
+
+type CommitRow =
+  { branch      :: BranchName
   , hash        :: CommitShortHash
-  , branch      :: BranchName
-  , created     :: DateTime
+  , authorImg   :: URI
+  , commitTitle :: String
+  }
+
+type PipelineRow =
+  { commit      :: CommitRow
+  , created     :: JSDate
   , status      :: PipelineStatus
   , id          :: PipelineId
   , project     :: Project
@@ -29,7 +34,7 @@ type PipelineRow =
   }
 
 
-getUniqueStages :: Jobs -> Array JobStatus
+getUniqueStages :: Array Job -> Array JobStatus
 getUniqueStages jobs = map _.status
                        $ sortWith _.id
                        $ mapMaybe (\grp -> last
@@ -38,3 +43,17 @@ getUniqueStages jobs = map _.status
                        $ groupBy (\a b -> a.name == b.name)
                        $ sortWith _.name jobs
 
+
+{-
+makePipelineRow :: NonEmpty Array Job -> PipelineRow
+makePipelineRow jobs = ?a
+  where
+    job = NE.head jobs
+  --{ authorImg: throwLeft $ URI.runParseURI  }
+
+
+makePipelineRows :: Jobs -> Array PipelineRow
+makePipelineRows jobs = map makePipelineRow
+                        $ groupBy (\a b -> a.project.name == b.project.name)
+                        $ sortWith (\j -> j.project.name) jobs
+-}

--- a/src/Dashboard/View.purs
+++ b/src/Dashboard/View.purs
@@ -13,7 +13,6 @@ import Data.JSDate (JSDate)
 import Data.Newtype (unwrap)
 import Data.String as String
 import Data.Time.Duration (Milliseconds(..))
-import Data.URI (printURI)
 import Halogen.HTML (HTML, ClassName(..))
 import Halogen.HTML as H
 import Halogen.HTML.CSS (style)
@@ -111,7 +110,7 @@ formatCommit { authorImg
              } =
   H.div
     [ ]
-    [ authorImage $ printURI authorImg
+    [ authorImage authorImg
     , divider
     , fontAwesome CodeFork []
     , H.b_ [ H.text branch ]

--- a/src/Dashboard/View.purs
+++ b/src/Dashboard/View.purs
@@ -1,23 +1,25 @@
 module Dashboard.View where
 
 import Prelude
-import Halogen.HTML (HTML)
+
+import Halogen.HTML (HTML, ClassName (..))
 import Halogen.HTML as H
 import Halogen.HTML.Properties as P
-import Halogen.HTML.CSS (style) as P
+import Halogen.HTML.CSS (style)
 import Data.Generic.Rep (class Generic)
 import Data.Generic.Rep.Show (genericShow)
 import Data.String as String
 import CSS as CSS
 import CSS.TextAlign as CSS
 import CSS (px, em)
+import Gitlab
 
 authorImage :: ∀ p i. String -> HTML p i
 authorImage url =
   H.img
     [ P.height 20
     , P.width 20
-    , P.style do
+    , style do
         CSS.borderRadius (20.0 # px) (20.0 # px) (20.0 # px) (20.0 # px)
     ]
 
@@ -64,21 +66,6 @@ fontAwesomeClasses :: Icon -> Array ClassName
 fontAwesomeClasses icon =
   ClassName <$> [ "fa", "fa-" <> iconName icon ]
 
-data JobStatus
-  = JobCreated
-  | JobManual
-  | JobRunning
-  | JobPending
-  | JobSuccess
-  | JobFailed
-  | JobCanceled
-  | JobSkipped
-
-derive instance genericJobStatus :: Generic JobStatus _
-
-instance showJobStatus :: Show JobStatus where
-  show = genericShow
-
 statusIcon :: ∀ p i. JobStatus -> HTML p i
 statusIcon JobRunning =
   H.span
@@ -98,25 +85,12 @@ statusIcon status =
     []
 
 
-data PipelineStatus
-  = Running
-  | Pending
-  | Success
-  | Failed
-  | Canceled
-  | Skipped
-
-derive instance genericPipelineStatus :: Generic PipelineStatus _
-
-instance showPipelineStatus :: Show PipelineStatus where
-  show = genericShow
-
 type Pipeline = { id :: String, status :: PipelineStatus, repo :: String, commit :: Commit, stages :: Array JobStatus, runningTime :: String}
 
 formatStatus :: ∀ p a. Pipeline -> HTML p a
 formatStatus { id, status } =
   H.div
-    [ P.style do
+    [ style do
         CSS.paddingLeft (2.0 # em)
     ]
     [ H.text $ "#" <> id
@@ -144,7 +118,7 @@ formatCommit commit =
     ]
   where
     divider =
-      H.span [ P.style (CSS.marginLeft (1.0 # em)) ] [ ]
+      H.span [ style (CSS.marginLeft (1.0 # em)) ] [ ]
 
 formatTimes
   :: ∀ p a.
@@ -152,7 +126,7 @@ formatTimes
   -> HTML p a
 formatTimes { when, runningTime } =
   H.div
-    [ P.style do
+    [ style do
         CSS.textAlign CSS.rightTextAlign
         CSS.paddingRight (2.0 # em)
     ]
@@ -185,14 +159,14 @@ formatPipeline pipeline =
      , [ formatTimes { when: "FIXME ago", runningTime: pipeline.runningTime } ]
      ]
 
-   cell :: ∀ p i. Array (HTML p i) -> HTML p i
+   cell :: Array (HTML p i) -> HTML p i
    cell =
      H.td
-       [ P.style do
+       [ style do
            CSS.textWhitespace CSS.whitespaceNoWrap
        ]
 
-   row :: ∀ p i. Array (HTML p i) -> HTML p i
+   row :: Array (HTML p i) -> HTML p i
    row =
      H.tr
        [ P.classes [ rowColor pipeline.status ] ]

--- a/src/Gitlab.purs
+++ b/src/Gitlab.purs
@@ -3,16 +3,14 @@ module Gitlab where
 import Prelude
 
 import Control.Monad.Aff (Aff, error, throwError)
-import Control.Monad.Eff.Class (liftEff)
 import Control.Monad.Eff.Unsafe (unsafePerformEff)
 import Data.Either (Either(..))
 import Data.Foreign.Generic.EnumEncoding (genericDecodeEnum, genericEncodeEnum)
 import Data.Generic.Rep (class Generic)
 import Data.Generic.Rep.Show (genericShow)
-import Data.JSDate (JSDate, LOCALE, parse, toDateString)
+import Data.JSDate (JSDate, parse)
 import Data.Maybe (Maybe(..))
 import Data.Newtype (class Newtype)
-import Data.Record (set)
 import Data.String (toLower, drop)
 import Network.HTTP.Affjax (AJAX, get)
 import Network.HTTP.StatusCode (StatusCode(..))
@@ -80,6 +78,7 @@ derive newtype instance readforeignPipelineId :: ReadForeign PipelineId
 derive newtype instance writeforeignPipelineId :: WriteForeign PipelineId
 
 newtype JobId = JobId Int
+derive newtype instance eqJobId :: Eq JobId
 derive newtype instance ordJobId :: Ord JobId
 derive newtype instance readforeignJobId :: ReadForeign JobId
 derive newtype instance writeforeignJobId :: WriteForeign JobId
@@ -148,7 +147,7 @@ getProjects (BaseUrl baseUrl) (Token token) = do
 
 getJobs :: forall a.
            BaseUrl -> Token -> Project
-           -> Aff (ajax :: AJAX, locale :: LOCALE | a) Jobs
+           -> Aff (ajax :: AJAX | a) Jobs
 getJobs (BaseUrl baseUrl) (Token token) project = do
   let url = baseUrl
             <> "/api/v4/projects/"

--- a/src/Gitlab.purs
+++ b/src/Gitlab.purs
@@ -59,6 +59,7 @@ instance showJobStatus :: Show JobStatus where
   show = genericShow
 
 newtype ProjectId = ProjectId Int
+derive newtype instance showProjectId :: Show ProjectId
 derive newtype instance readforeignProjectId :: ReadForeign ProjectId
 derive newtype instance writeforeignProjectId :: WriteForeign ProjectId
 
@@ -153,7 +154,7 @@ getJobs :: forall a.
 getJobs (BaseUrl baseUrl) (Token token) project = do
   let url = baseUrl
             <> "/api/v4/projects/"
-            <> writeJSON project.id -- same as show in this case
+            <> show project.id
             <> "/jobs?private_token="
             <> token
             <> "&per_page=100"

--- a/src/Gitlab.purs
+++ b/src/Gitlab.purs
@@ -31,6 +31,10 @@ newtype PipelineId = PipelineId Int
 derive newtype instance readforeignPipelineId :: ReadForeign PipelineId
 derive newtype instance writeforeignPipelineId :: WriteForeign PipelineId
 
+newtype JobId = JobId Int
+derive newtype instance readforeignJobId :: ReadForeign JobId
+derive newtype instance writeforeignJobId :: WriteForeign JobId
+
 newtype BranchName = BranchName String
 derive newtype instance readforeignBranchName :: ReadForeign BranchName
 derive newtype instance writeforeignBranchName :: WriteForeign BranchName
@@ -66,6 +70,7 @@ type Job =
   , ref         :: BranchName
   , pipeline    :: Pipeline
   , status      :: JobStatus
+  , id          :: JobId
   , created_at  :: ISODateString
   , started_at  :: Maybe ISODateString
   , finished_at :: Maybe ISODateString

--- a/src/Gitlab.purs
+++ b/src/Gitlab.purs
@@ -59,6 +59,8 @@ derive newtype instance readforeignProjectId :: ReadForeign ProjectId
 derive newtype instance writeforeignProjectId :: WriteForeign ProjectId
 
 newtype ProjectName = ProjectName String
+derive newtype instance eqProjectName :: Eq ProjectName
+derive newtype instance ordProjectName :: Ord ProjectName
 derive newtype instance readforeignProjectName :: ReadForeign ProjectName
 derive newtype instance writeforeignProjectName :: WriteForeign ProjectName
 

--- a/src/Gitlab.purs
+++ b/src/Gitlab.purs
@@ -71,8 +71,15 @@ derive newtype instance readforeignPipelineId :: ReadForeign PipelineId
 derive newtype instance writeforeignPipelineId :: WriteForeign PipelineId
 
 newtype JobId = JobId Int
+derive newtype instance ordJobId :: Ord JobId
 derive newtype instance readforeignJobId :: ReadForeign JobId
 derive newtype instance writeforeignJobId :: WriteForeign JobId
+
+newtype JobName = JobName String
+derive newtype instance eqJobName :: Eq JobName
+derive newtype instance ordJobName :: Ord JobName
+derive newtype instance readforeignJobName :: ReadForeign JobName
+derive newtype instance writeforeignJobName :: WriteForeign JobName
 
 newtype BranchName = BranchName String
 derive newtype instance readforeignBranchName :: ReadForeign BranchName
@@ -110,6 +117,7 @@ type Job =
   , pipeline    :: Pipeline
   , status      :: JobStatus
   , id          :: JobId
+  , name        :: JobName
   , created_at  :: ISODateString
   , started_at  :: Maybe ISODateString
   , finished_at :: Maybe ISODateString

--- a/src/Gitlab.purs
+++ b/src/Gitlab.purs
@@ -8,6 +8,7 @@ import Data.Foreign.Generic.EnumEncoding (genericDecodeEnum, genericEncodeEnum)
 import Data.Generic.Rep (class Generic)
 import Data.Generic.Rep.Show (genericShow)
 import Data.Maybe (Maybe(..))
+import Data.Newtype (class Newtype)
 import Data.String (toLower, drop)
 import Network.HTTP.Affjax (AJAX, get)
 import Network.HTTP.StatusCode (StatusCode(..))
@@ -59,6 +60,7 @@ derive newtype instance readforeignProjectId :: ReadForeign ProjectId
 derive newtype instance writeforeignProjectId :: WriteForeign ProjectId
 
 newtype ProjectName = ProjectName String
+derive instance newtypeProjectName :: Newtype ProjectName _
 derive newtype instance eqProjectName :: Eq ProjectName
 derive newtype instance ordProjectName :: Ord ProjectName
 derive newtype instance readforeignProjectName :: ReadForeign ProjectName

--- a/src/Gitlab.purs
+++ b/src/Gitlab.purs
@@ -74,6 +74,8 @@ derive newtype instance readforeignCommitShortHash :: ReadForeign CommitShortHas
 derive newtype instance writeforeignCommitShortHash :: WriteForeign CommitShortHash
 
 newtype PipelineId = PipelineId Int
+derive newtype instance eqPipelineId :: Eq PipelineId
+derive newtype instance ordPipelineId :: Ord PipelineId
 derive newtype instance readforeignPipelineId :: ReadForeign PipelineId
 derive newtype instance writeforeignPipelineId :: WriteForeign PipelineId
 

--- a/src/Gitlab.purs
+++ b/src/Gitlab.purs
@@ -4,7 +4,11 @@ import Prelude
 
 import Control.Monad.Aff (Aff, error, throwError)
 import Data.Either (Either(..))
+import Data.Foreign.Generic.EnumEncoding (genericDecodeEnum, genericEncodeEnum)
+import Data.Generic.Rep (class Generic)
+import Data.Generic.Rep.Show (genericShow)
 import Data.Maybe (Maybe(..))
+import Data.String (toLower, drop)
 import Network.HTTP.Affjax (AJAX, get)
 import Network.HTTP.StatusCode (StatusCode(..))
 import Simple.JSON (class ReadForeign, class WriteForeign, readJSON, writeJSON)
@@ -12,8 +16,43 @@ import Simple.JSON (class ReadForeign, class WriteForeign, readJSON, writeJSON)
 newtype BaseUrl = BaseUrl String
 newtype Token = Token String
 
-type PipelineStatus = String -- TODO: make enum
-type JobStatus      = String -- TODO: make enum
+data PipelineStatus
+  = Running
+  | Pending
+  | Success
+  | Failed
+  | Canceled
+  | Skipped
+
+derive instance eqPipelineStatus :: Eq PipelineStatus
+derive instance genericPipelineStatus :: Generic PipelineStatus _
+
+instance readForeignPipelineStatus :: ReadForeign PipelineStatus where
+  readImpl = genericDecodeEnum {constructorTagTransform: toLower}
+instance writeForeignPipelineStatus :: WriteForeign PipelineStatus where
+  writeImpl = genericEncodeEnum {constructorTagTransform: toLower}
+instance showPipelineStatus :: Show PipelineStatus where
+  show = genericShow
+
+data JobStatus
+  = JobCreated
+  | JobManual
+  | JobRunning
+  | JobPending
+  | JobSuccess
+  | JobFailed
+  | JobCanceled
+  | JobSkipped
+
+derive instance eqJobStatus :: Eq JobStatus
+derive instance genericJobeStatus :: Generic JobStatus _
+
+instance readForeignJobStatus :: ReadForeign JobStatus where
+  readImpl = genericDecodeEnum {constructorTagTransform: (drop 3) <<< toLower}
+instance writeForeignJobStatus :: WriteForeign JobStatus where
+  writeImpl = genericEncodeEnum {constructorTagTransform: (drop 3) <<< toLower}
+instance showJobStatus :: Show JobStatus where
+  show = genericShow
 
 newtype ProjectId = ProjectId Int
 derive newtype instance readforeignProjectId :: ReadForeign ProjectId

--- a/src/Main.purs
+++ b/src/Main.purs
@@ -6,7 +6,7 @@ import Control.Monad.Aff (Fiber, launchAff)
 import Control.Monad.Aff.Console (CONSOLE, log)
 import Control.Monad.Eff (Eff)
 import DOM (DOM)
-import Gitlab (getProjects, getJobs, BaseUrl(..), Token(..))
+import Gitlab (BaseUrl(..), ProjectId(..), ProjectName(..), Token(..), getJobs, getProjects)
 import Network.HTTP.Affjax (AJAX)
 import Simple.JSON (writeJSON)
 import URLSearchParams as URLParams
@@ -26,9 +26,10 @@ main :: Main
 main = do
   token   <- Token   <$> URLParams.get "private_token"
   baseUrl <- BaseUrl <$> URLParams.get "gitlab_url"
+  -- TODO: display error if parameters are not provided
   launchAff $ do
     projects <- getProjects baseUrl token
     log $ writeJSON projects
-    let proj = {name: "faro", id: 64} -- example project with pipelines
+    let proj = {name: (ProjectName "faro"), id: (ProjectId 64)} -- example project with pipelines
     jobs <- getJobs baseUrl token proj
     log $ writeJSON jobs

--- a/src/Main.purs
+++ b/src/Main.purs
@@ -7,9 +7,10 @@ import Control.Monad.Aff.Console (CONSOLE, log)
 import Control.Monad.Eff (Eff)
 import DOM (DOM)
 import Gitlab (BaseUrl(..), ProjectId(..), ProjectName(..), Token(..), getJobs, getProjects)
+import Global.Unsafe (unsafeStringify)
 import Network.HTTP.Affjax (AJAX)
-import Simple.JSON (writeJSON)
 import URLSearchParams as URLParams
+
 
 type Main = forall e.
             Eff ( ajax :: AJAX
@@ -29,7 +30,7 @@ main = do
   -- TODO: display error if parameters are not provided
   launchAff $ do
     projects <- getProjects baseUrl token
-    log $ writeJSON projects
+    log $ unsafeStringify projects
     let proj = {name: (ProjectName "faro"), id: (ProjectId 64)} -- example project with pipelines
     jobs <- getJobs baseUrl token proj
-    log $ writeJSON jobs
+    log $ unsafeStringify jobs

--- a/src/Main.purs
+++ b/src/Main.purs
@@ -2,35 +2,60 @@ module Main where
 
 import Prelude
 
-import Control.Monad.Aff (Fiber, launchAff)
+import Dashboard.Component as Dash
+import Control.Monad.Aff (Aff, Milliseconds(..), delay)
 import Control.Monad.Aff.Console (CONSOLE, log)
 import Control.Monad.Eff (Eff)
-import DOM (DOM)
-import Gitlab (BaseUrl(..), ProjectId(..), ProjectName(..), Token(..), getJobs, getProjects)
+import Dashboard.Model as Model
+import Data.Array (uncons)
+import Data.Maybe (Maybe(..))
+import Gitlab (BaseUrl(..), Token(..), getJobs, getProjects)
 import Global.Unsafe (unsafeStringify)
+import Halogen as H
+import Halogen.Aff as HA
+import Halogen.VDom.Driver (runUI)
 import Network.HTTP.Affjax (AJAX)
 import URLSearchParams as URLParams
 
 
-type Main = forall e.
-            Eff ( ajax :: AJAX
-                , console :: CONSOLE
-                , dom :: DOM
-                | e)
-                (Fiber ( ajax :: AJAX
-                       , console :: CONSOLE
-                       , dom :: DOM
-                       | e)
-                       Unit)
+pollProjects ::
+  forall a eff.
+  BaseUrl
+  -> Token
+  -> (Dash.Query Unit -> Aff (ajax :: AJAX, console :: CONSOLE | eff) a)
+  -> Aff (ajax :: AJAX, console :: CONSOLE | eff) Unit
+pollProjects baseUrl token query = do
+  -- Get projects, poll all of them for jobs
+  log "Fetching list of projects..."
+  projects <- getProjects baseUrl token
+  fetchJobs projects
 
-main :: Main
+  -- Wait 30 secs and recur
+  delay (Milliseconds 30000.0)
+  _ <- pollProjects baseUrl token query
+  pure unit
+  where
+    -- If list of projects is empty, return
+    -- If not, take the first, get jobs, and upsert in the Component
+    -- Then wait 1s, and recur to fetch the rest
+    fetchJobs projects = case uncons projects of
+      Nothing -> pure unit
+      Just { head: p, tail: ps } -> do
+        log $ "Fetching Jobs for Project with id: " <> unsafeStringify p.id
+        jobs <- getJobs baseUrl token p
+        _ <- query
+             $ H.action
+             $ Dash.UpsertProjectPipelines
+             $ Model.makeProjectRows jobs
+        delay (Milliseconds 1000.0)
+        fetchJobs ps
+
+main :: forall e. Eff (HA.HalogenEffects (ajax :: AJAX, console :: CONSOLE | e)) Unit
 main = do
   token   <- Token   <$> URLParams.get "private_token"
   baseUrl <- BaseUrl <$> URLParams.get "gitlab_url"
   -- TODO: display error if parameters are not provided
-  launchAff $ do
-    projects <- getProjects baseUrl token
-    log $ unsafeStringify projects
-    let proj = {name: (ProjectName "faro"), id: (ProjectId 64)} -- example project with pipelines
-    jobs <- getJobs baseUrl token proj
-    log $ unsafeStringify jobs
+  HA.runHalogenAff $ do
+    body <- HA.awaitBody
+    io <- runUI Dash.ui unit body
+    pollProjects baseUrl token io.query

--- a/src/Main.purs
+++ b/src/Main.purs
@@ -32,8 +32,7 @@ pollProjects baseUrl token query = do
 
   -- Wait 30 secs and recur
   delay (Milliseconds 30000.0)
-  _ <- pollProjects baseUrl token query
-  pure unit
+  void $ pollProjects baseUrl token query
   where
     -- If list of projects is empty, return
     -- If not, take the first, get jobs, and upsert in the Component

--- a/src/Moment.js
+++ b/src/Moment.js
@@ -1,0 +1,12 @@
+"use strict";
+
+exports.formatTime_ = function(milliseconds) {
+  return moment("2015-01-01")
+    .startOf('day')
+    .milliseconds(milliseconds)
+    .format('HH:mm:ss');
+};
+
+exports.fromNow_ = function(jsDate) {
+  return moment(jsDate).fromNow();
+};

--- a/src/Moment.purs
+++ b/src/Moment.purs
@@ -1,0 +1,16 @@
+module Moment where
+
+import Data.JSDate (JSDate, toUTCString)
+import Data.Time.Duration (Milliseconds(..))
+import Prelude (($))
+
+foreign import formatTime_ :: Number -> String
+foreign import fromNow_ :: String -> String
+
+-- | Formats time in hh:mm:ss format
+formatMillis :: Milliseconds -> String
+formatMillis (Milliseconds n) = formatTime_ n
+
+fromNow :: JSDate -> String
+fromNow date = fromNow_ $ toUTCString date
+


### PR DESCRIPTION
When #6 will go in, we will still be missing from the port the part of the application that converts Gitlab API datastructure to our View datastructure.

As we agreed, we should define such datastructure (essentially a record called `PipelineRow`) in the `Dashboard.Model` module.

Functions to port:
- [x] `format_time` -> `Moment.formatMillis :: Milliseconds -> String`
- [x] `moment.fromNow` -> `Moment.fromNow :: JSDate -> String`
- [x] `row_colors` -> `rowColors :: Gitlab.PipelineStatus -> ClassName`
- [x] `status_icons` -> `statusIcons :: Gitlab.JobStatus -> String`
- [x]  `getUniqueStages` (given a list of jobs with the same stage name, get the latest by Id)
- [x] `processJobs` -> `processJobs :: Array Gitlab.Job -> Array PipelineRow`
- [x] `fetchJobs` (after we get the projects, we get the jobs for all of them. Wait 1s between calls)
- [x] `fetchProjects` (every 30 seconds call `getProjects`)

Other things to do in the meanwhile:
- [x] Fix `Gitlab` types to lie less
- [x] Define `PipelineRow` type