### PR TITLE
Fix running times

### DIFF
--- a/src/Dashboard/Model.purs
+++ b/src/Dashboard/Model.purs
@@ -67,7 +67,7 @@ makePipelineRow jobs =
       started  <- minimum $ mapMaybe (toDateTime <=< _.started_at) pipelineJobs
       -- Parse all into DateTime, get the latest finishing time
       finished <- maximum $ mapMaybe (toDateTime <=< _.finished_at) pipelineJobs
-      pure $ diff started finished
+      pure $ diff finished started
 
 -- | Given all the Jobs for a Project, makes a PipelineRow out of each Pipeline
 makeProjectRows :: Gitlab.Jobs -> Array PipelineRow


### PR DESCRIPTION
Change parameter order given to `diff` (subtract smaller from larger) so that a positive value is always returned.

Fixes issue #14 

