### PR TITLE
Use Docker multistage build

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,2 +1,6 @@
 node_modules
 output
+.git
+.gitignore
+.gitlab-ci.yml
+Dockerfile

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,15 +4,13 @@ FROM node:10.8 as yarnbuild
 WORKDIR /data
 COPY . /data/
 
-RUN npm install
-RUN npm run install
+RUN yarn install --pure-lockfile --cache-folder .yarn-cache
 
 # Stage 2
 FROM nginx:1.14-alpine
 
 COPY --from=yarnbuild /data/index.html /data/app.js /usr/share/nginx/html/
 COPY --from=yarnbuild /data/node_modules /usr/share/nginx/html/node_modules/
-COPY --from=yarnbuild /data/output /usr/share/nginx/html/output/
 
 EXPOSE 80
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,18 @@
-FROM node:10.6.0
+# Stage 1
+FROM node:10.8 as yarnbuild
 
 WORKDIR /data
 COPY . /data/
 
 RUN npm install
 RUN npm run install
-RUN npm install http-server -g
+
+# Stage 2
+FROM nginx:1.14-alpine
+
+COPY --from=yarnbuild /data/index.html /data/app.js /usr/share/nginx/html/
+COPY --from=yarnbuild /data/node_modules /usr/share/nginx/html/node_modules/
+COPY --from=yarnbuild /data/output /usr/share/nginx/html/output/
 
 EXPOSE 80
-CMD http-server -p 80
+


### PR DESCRIPTION
I've found your project pretty cool and I wanted to contribute to it.

I know my ways with Docker and therefore I'm proposing small optimisations.

What I've done is transform the Dockerfile into a multistage build. Meaning the first stage is only there to build the application and is "discarded" (1), the second stage picks up just the build data, nothing else.

Note that I am not at all experienced with npm, node or purescript/pulp. So one can do a better job at packaging a production application. I've grabbed the entire `output/` and `node_modules/` directories into the final container image and I'm pretty sure this is too much.

The total build time is about the same, but the multistage approach provides the following advantages:

* Final image (the "production image") **size** is **reduced from 830MB to 120MB** (both uncompressed)
* Container **startup** time went **down from about 11s to 4s** (on my underpower laptop with a SSD)
* Container resource usage has been improved:
  * **RAM** usage went **down from 14MB to 2MB**
  * **IO** usage for startup went **down from 31.9MB to 3.8MB**

In addition by running with nginx instead of http-server, this is using a more robust, battle-proven web server with a good security track. On top of that, the nginx server is running as a standard user and not as root inside the container. So all the better.

Measurements done on Fedora 28, using btrfs storage backend for Docker CE 18.06.0, on a laptop with a SSD and dual core mobile CPU.

*(1): The first stage is not really discarded, it is still cached by Docker so it can still accelerate subsequent builds, but only a subset of the data from 1st stage will be use in 2nd stage.*